### PR TITLE
Added Mixin to patch FUR Scythe Sweep

### DIFF
--- a/src/main/java/eaglemixins/EagleMixins.java
+++ b/src/main/java/eaglemixins/EagleMixins.java
@@ -27,6 +27,7 @@ public class EagleMixins {
         MinecraftForge.EVENT_BUS.register(DismountHandler.class);
         MinecraftForge.EVENT_BUS.register(DispelEntityHandler.class);
         MinecraftForge.EVENT_BUS.register(EntityRenameCancelHandler.class);
+        MinecraftForge.EVENT_BUS.register(FURHandler.class);
         MinecraftForge.EVENT_BUS.register(HealthValidationHandler.class);
         MinecraftForge.EVENT_BUS.register(PotionEffectsByFluidsHandler.class);
         MinecraftForge.EVENT_BUS.register(RandomTippedArrowHandler.class);

--- a/src/main/java/eaglemixins/handlers/FURHandler.java
+++ b/src/main/java/eaglemixins/handlers/FURHandler.java
@@ -1,0 +1,19 @@
+package eaglemixins.handlers;
+
+import bettercombat.mod.event.RLCombatSweepEvent;
+import com.Fishmod.mod_LavaCow.init.FishItems;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class FURHandler {
+
+    @SubscribeEvent
+    public static void onScytheSweep(RLCombatSweepEvent event) {
+        if(event.getItemStack().getItem() == FishItems.REAPERS_SCYTHE) {
+            EntityPlayer attacker = event.getEntityPlayer();
+            event.setDoSweep(true);
+            event.setSweepingAABB(event.getSweepingAABB().grow(1.0F, 0, 1.0F));
+            attacker.world.playSound((EntityPlayer)null, attacker.posX, attacker.posY, attacker.posZ, FishItems.ENTITY_SCARECROW_SCYTHE, attacker.getSoundCategory(), 1.0F, 1.0F / (attacker.world.rand.nextFloat() * 0.4F + 0.8F));
+        }
+    }
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/ItemFishCustomWeaponMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/ItemFishCustomWeaponMixin.java
@@ -1,0 +1,21 @@
+package eaglemixins.mixin.fishsundeadrising;
+
+import com.Fishmod.mod_LavaCow.item.ItemFishCustomWeapon;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ItemFishCustomWeapon.class)
+public abstract class ItemFishCustomWeaponMixin {
+
+    // Cancel custom sweep handling but execute dura loss
+    @Redirect(
+            method = "hitEntity",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;", ordinal = 0)
+    )
+    private Item eagleMixins_furScythe_hitEntity(ItemStack instance){
+        return null;
+    }
+}

--- a/src/main/resources/mixins.eaglemixins.fishsundeadrising.json
+++ b/src/main/resources/mixins.eaglemixins.fishsundeadrising.json
@@ -10,6 +10,7 @@
     "EntitySandBurstMixin",
     "EntityUndertakerAIUseSpellMixin",
     "ItemCrownMixin",
+    "ItemFishCustomWeaponMixin",
     "ModEventHandlerMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Added Mixin for FUR "Azrael's Scythe" for FUR 1.4.2, NOTE: FUR 1.5.2 still uses a custom sweep so Mixin still valid in this case

+ Azrael's Scythe Sweep now handled by RLCombat
- Did not implement Armor Piercing, was a removed feature since 1.3.1, Tooltip is fixed with FUR 1.5.0+