### PR TITLE
Ported FUR 1.4.2 fixes from old rlmixins

### DIFF
--- a/src/main/java/eaglemixins/EagleMixinsPlugin.java
+++ b/src/main/java/eaglemixins/EagleMixinsPlugin.java
@@ -29,6 +29,8 @@ public class EagleMixinsPlugin implements IFMLLoadingPlugin {
 		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.vc.json", () -> Loader.isModLoaded("variedcommodities"));
 		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.xat.json", () -> Loader.isModLoaded("xat"));
 
+		// Temporary FUR 1.4.2 fixes because we are not using 1.5.0+
+		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.furold.json", () -> Loader.isModLoaded("mod_lavacow"));
 	}
 
 	@Override

--- a/src/main/java/eaglemixins/EagleMixinsPlugin.java
+++ b/src/main/java/eaglemixins/EagleMixinsPlugin.java
@@ -30,7 +30,7 @@ public class EagleMixinsPlugin implements IFMLLoadingPlugin {
 		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.xat.json", () -> Loader.isModLoaded("xat"));
 
 		// Temporary FUR 1.4.2 fixes because we are not using 1.5.0+
-		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.furold.json", () -> Loader.isModLoaded("mod_lavacow"));
+		FermiumRegistryAPI.enqueueMixin(true, "mixins.eaglemixins.furold.json", () -> Loader.isModLoaded("mod_lavacow") && Loader.instance().getIndexedModList().get("mod_lavacow").getVersion().equals("1.4.2"));
 	}
 
 	@Override

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityAquaMobMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityAquaMobMixin.java
@@ -1,0 +1,20 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.entities.aquatic.EntityAquaMob;
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntityAquaMob.class)
+public abstract class EntityAquaMobMixin extends EntityMob {
+	
+	public EntityAquaMobMixin(World worldIn) {
+		super(worldIn);
+	}
+	
+	@Override
+	public boolean isNotColliding() {
+		return this.world.checkNoEntityCollision(this.getEntityBoundingBox(), this)
+				&& this.world.getCollisionBoxes(this, this.getEntityBoundingBox()).isEmpty();
+	}
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntitySkeletonKingMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntitySkeletonKingMixin.java
@@ -1,0 +1,23 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.client.Modconfig;
+import com.Fishmod.mod_LavaCow.entities.EntitySkeletonKing;
+import com.Fishmod.mod_LavaCow.util.LootTableHandler;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntitySkeletonKing.class)
+public abstract class EntitySkeletonKingMixin {
+
+    @Inject(
+            method = "getLootTable",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void rlmixins_fishsUndeadRisingEntitySkeletonKing(CallbackInfoReturnable<ResourceLocation> cir) {
+        cir.setReturnValue(!Modconfig.SkeletonKing_Loot_Option ? LootTableHandler.SKELETON_KING : null);
+    }
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityWendigoMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityWendigoMixin.java
@@ -1,0 +1,87 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.client.Modconfig;
+import com.Fishmod.mod_LavaCow.entities.EntityWendigo;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityWendigo.class)
+public abstract class EntityWendigoMixin extends EntityMob {
+	
+	@Shadow(remap = false)
+	private int attackTimer;
+	
+	@Shadow(remap = false)
+	private int jumpTimer;
+	
+	@Shadow(remap = false)
+	public abstract int getAttackTimer();
+	
+	@Shadow(remap = false)
+	public byte AttackStance;
+	
+	public EntityWendigoMixin(World worldIn) {
+		super(worldIn);
+	}
+	
+	/**
+	 * @author fonnymunkey
+	 * @reason fix clientside effect checks
+	 */
+	@Overwrite
+	public void onLivingUpdate() {
+		super.onLivingUpdate();
+		if(this.attackTimer > 0) {
+			--this.attackTimer;
+		}
+		
+		if(this.jumpTimer > 0) {
+			--this.jumpTimer;
+		}
+		
+		if(this.world.isRemote) return;
+		
+		if(!Modconfig.SunScreen_Mode && this.world.isDaytime()) {
+			float f = this.getBrightness();
+			if(f > 0.5F && this.rand.nextFloat() * 30.0F < (f - 0.4F) * 2.0F && this.world.canSeeSky(new BlockPos(this.posX, this.posY + (double)this.getEyeHeight(), this.posZ))) {
+				this.setFire(40);
+			}
+		}
+		
+		if(this.getAttackTarget() != null && this.getDistanceSq(this.getAttackTarget()) < 4.0 && this.getAttackTimer() == 10 && this.deathTime <= 0) {
+			boolean flag = false;
+			if(this.AttackStance == 40) {
+				flag = this.getAttackTarget().attackEntityFrom(DamageSource.causeMobDamage(this), (float)this.getAttributeMap().getAttributeInstance(SharedMonsterAttributes.ATTACK_DAMAGE).getAttributeValue() * 1.5F);
+				if(this.getAttackTarget() instanceof EntityPlayer) {
+					((EntityPlayer)this.getAttackTarget()).disableShield(true);
+				}
+			}
+			else {
+				flag = this.getAttackTarget().attackEntityFrom(DamageSource.causeMobDamage(this), (float)this.getAttributeMap().getAttributeInstance(SharedMonsterAttributes.ATTACK_DAMAGE).getAttributeValue());
+			}
+			
+			if(flag) {
+				float f = this.world.getDifficultyForLocation(new BlockPos(this)).getAdditionalDifficulty();
+				if(this.getHeldItemMainhand().isEmpty() && this.isBurning() && this.rand.nextFloat() < f * 0.3F) {
+					this.getAttackTarget().setFire(2 * (int)f);
+				}
+				
+				if(this.getAttackTarget() instanceof EntityLivingBase) {
+					float local_difficulty = this.world.getDifficultyForLocation(new BlockPos(this)).getAdditionalDifficulty();
+					this.getAttackTarget().addPotionEffect(new PotionEffect(MobEffects.HUNGER, 140 * (int)local_difficulty, 4));
+				}
+			}
+		}
+		
+	}
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityZombieMushroomMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/EntityZombieMushroomMixin.java
@@ -1,0 +1,58 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.entities.EntityZombieMushroom;
+import com.Fishmod.mod_LavaCow.mod_LavaCow;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+import java.util.Random;
+
+@Mixin(EntityZombieMushroom.class)
+public abstract class EntityZombieMushroomMixin extends EntityZombie {
+	
+	@Shadow(remap = false)
+	private Vec3d[] spore_color;
+	
+	@Shadow(remap = false)
+	public abstract int getSkin();
+	
+	public EntityZombieMushroomMixin(World worldIn) {
+		super(worldIn);
+	}
+	
+	/**
+	 * @author fonnymunkey
+	 * @reason fix clientside effect checks
+	 */
+	@Overwrite
+	public void onUpdate() {
+		super.onUpdate();
+		if(!this.getEntityWorld().isRemote && this.ticksExisted % 20 == 0) {
+			List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox().grow(2.0, 2.0, 2.0));
+			if(!list.isEmpty()) {
+				float local_difficulty = this.world.getDifficultyForLocation(new BlockPos(this)).getAdditionalDifficulty();
+				for(Entity entity1 : list) {
+					if(entity1 instanceof EntityLivingBase) {
+						if(((EntityLivingBase)entity1).getActivePotionEffect(MobEffects.POISON) == null) {
+							((EntityLivingBase)entity1).addPotionEffect(new PotionEffect(MobEffects.POISON, 40 * (int)local_difficulty, 0));
+						}
+					}
+				}
+			}
+		}
+		
+		if(this.getEntityWorld().isRemote && this.ticksExisted % 5 == 0) {
+			mod_LavaCow.PROXY.spawnCustomParticle("spore", this.world, this.posX + (double)((new Random()).nextFloat() * this.width * 2.0F) - (double)this.width, this.posY + (double)((new Random()).nextFloat() * this.height), this.posZ + (double)((new Random()).nextFloat() * this.width * 2.0F) - (double)this.width, 0.0, 0.0, 0.0, (float)this.spore_color[this.getSkin()].x, (float)this.spore_color[this.getSkin()].y, (float)this.spore_color[this.getSkin()].z);
+		}
+	}
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemHolyGrenadeMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemHolyGrenadeMixin.java
@@ -1,0 +1,64 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityGhostBomb;
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntityHolyGrenade;
+import com.Fishmod.mod_LavaCow.entities.projectiles.EntitySonicBomb;
+import com.Fishmod.mod_LavaCow.init.FishItems;
+import com.Fishmod.mod_LavaCow.item.ItemFishCustom;
+import com.Fishmod.mod_LavaCow.item.ItemHolyGrenade;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(ItemHolyGrenade.class)
+public abstract class ItemHolyGrenadeMixin extends ItemFishCustom {
+	
+	public ItemHolyGrenadeMixin(String registryName, Item afteruse, CreativeTabs tab, boolean hasTooltip) {
+		super(registryName, afteruse, tab, hasTooltip);
+	}
+	
+	/**
+	 * @author fonnymunkey
+	 * @reason fix grenades not being consumed
+	 */
+	@Overwrite
+	public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn) {
+		ItemStack itemstack = playerIn.getHeldItem(handIn);
+		if(!worldIn.isRemote) {
+			worldIn.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, SoundEvents.ENTITY_SNOWBALL_THROW, SoundCategory.NEUTRAL, 0.5F, 0.4F / (itemRand.nextFloat() * 0.4F + 0.8F));
+			
+			if(itemstack.getItem().equals(FishItems.HOLY_GRENADE)) {
+				EntityHolyGrenade entitysnowball = new EntityHolyGrenade(worldIn, playerIn);
+				entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 1.5F, 1.0F);
+				worldIn.spawnEntity(entitysnowball);
+			}
+			else if(itemstack.getItem().equals(FishItems.GHOSTBOMB)) {
+				EntityGhostBomb entitysnowball = new EntityGhostBomb(worldIn, playerIn);
+				entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 0.5F, 1.0F);
+				worldIn.spawnEntity(entitysnowball);
+			}
+			else if(itemstack.getItem().equals(FishItems.SONICBOMB)) {
+				EntitySonicBomb entitysnowball = new EntitySonicBomb(worldIn, playerIn);
+				entitysnowball.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, -20.0F, 1.5F, 1.0F);
+				worldIn.spawnEntity(entitysnowball);
+			}
+			
+			if(!playerIn.capabilities.isCreativeMode) {
+				itemstack.shrink(1);
+				if(itemstack.getCount() <= 0) {
+					playerIn.inventory.deleteStack(itemstack);
+				}
+			}
+		}
+		return new ActionResult(EnumActionResult.SUCCESS, itemstack);
+	}
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemNetherStewMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemNetherStewMixin.java
@@ -1,0 +1,48 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.client.Modconfig;
+import com.Fishmod.mod_LavaCow.init.FishItems;
+import com.Fishmod.mod_LavaCow.item.ItemFishCustomFood;
+import com.Fishmod.mod_LavaCow.item.ItemNetherStew;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.init.MobEffects;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(ItemNetherStew.class)
+public abstract class ItemNetherStewMixin extends ItemFishCustomFood {
+	
+	public ItemNetherStewMixin(String registryName, int amount, float saturation, boolean isWolfFood, int duration, boolean hasTooltip) {
+		super(registryName, amount, saturation, isWolfFood, duration, hasTooltip);
+	}
+	
+	/**
+	 * @author fonnymunkey
+	 * @reason fix server crash and remove crazy resistance
+	 */
+	@Overwrite
+	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, EntityLivingBase entityLiving) {
+		super.onItemUseFinish(stack, worldIn, entityLiving);
+		if (this.equals(FishItems.GHOSTJELLY)) {
+			if(worldIn.isRemote) {
+				entityLiving.setVelocity(0.0, 2.0, 0.0);
+			}
+			else {
+				entityLiving.addPotionEffect(new PotionEffect(MobEffects.LEVITATION, 60, 2));
+				entityLiving.playSound(SoundEvents.ENTITY_FIREWORK_LAUNCH, 1.0F, 1.0F);
+			}
+		}
+		
+		if (!worldIn.isRemote && (Modconfig.Bowls_Stack || stack.getCount() > stack.getMaxStackSize()) && entityLiving instanceof EntityPlayer && !((EntityPlayer)entityLiving).isCreative()) {
+			((EntityPlayer)entityLiving).inventory.addItemStackToInventory(new ItemStack(Items.BOWL));
+		}
+		
+		return !Modconfig.Bowls_Stack && stack.getCount() <= stack.getMaxStackSize() ? new ItemStack(Items.BOWL) : stack;
+	}
+}

--- a/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemSkeletonKingCrownMixin.java
+++ b/src/main/java/eaglemixins/mixin/fishsundeadrising/temp/ItemSkeletonKingCrownMixin.java
@@ -1,0 +1,31 @@
+package eaglemixins.mixin.fishsundeadrising.temp;
+
+import com.Fishmod.mod_LavaCow.client.model.armor.ModelCrown;
+import com.Fishmod.mod_LavaCow.item.ItemSkeletonKingCrown;
+import net.minecraft.client.model.ModelBiped;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemSkeletonKingCrown.class)
+public abstract class ItemSkeletonKingCrownMixin {
+	
+	@Unique
+	private ModelCrown rlmixins$modelCrown;
+	
+	@Inject(
+			method = "getArmorModel",
+			at = @At("HEAD"),
+			cancellable = true,
+			remap = false
+	)
+	public void rlmixins_fishsUndeadRisingItemSkeletonKingCrown_getArmorModel(EntityLivingBase player, ItemStack stack, EntityEquipmentSlot armorSlot, ModelBiped modelBiped, CallbackInfoReturnable<ModelBiped> cir) {
+		if(this.rlmixins$modelCrown == null) this.rlmixins$modelCrown = new ModelCrown(1.0F);
+		cir.setReturnValue(this.rlmixins$modelCrown);
+	}
+}

--- a/src/main/resources/mixins.eaglemixins.furold.json
+++ b/src/main/resources/mixins.eaglemixins.furold.json
@@ -1,0 +1,22 @@
+{
+  "required": true,
+  "package": "eaglemixins.mixin.fishsundeadrising.temp",
+  "refmap": "mixins.eaglemixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "EntityAquaMobMixin",
+    "EntitySkeletonKingMixin",
+    "EntityWendigoMixin",
+    "EntityZombieMushroomMixin",
+    "ItemHolyGrenadeMixin",
+    "ItemNetherStewMixin"
+  ],
+  "client": [
+    "ItemSkeletonKingCrownMixin"
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  }
+}


### PR DESCRIPTION
Unless you want to add "re-introduced a memory leak and crash" to the changelogs.

Lazy copy paste port of fixes, didn't even bother renaming rlmixin names. Will hard crash if used with updated FUR.

Delete when you actually do decide to update.